### PR TITLE
feat(examples): add instruction_executor custom workflow example

### DIFF
--- a/examples/python/custom_workflows/instruction_executor/.env.example
+++ b/examples/python/custom_workflows/instruction_executor/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key_here

--- a/examples/python/custom_workflows/instruction_executor/README.md
+++ b/examples/python/custom_workflows/instruction_executor/README.md
@@ -1,0 +1,36 @@
+# Instruction Executor Workflow
+
+This is an example of an Agenta Custom Workflow that takes a piece of `text` and a set of `instructions`, and executes those instructions on the text using an LLM.
+
+## Features
+- Utilizes the OpenAI API for instruction execution.
+- Configurable system prompt, model choice, temperature, and max tokens.
+- Instrumented with OpenTelemetry for tracing.
+
+## Setup
+
+1. **Install dependencies:**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Set up environment variables:**
+   Copy `.env.example` to `.env` and add your OpenAI API key.
+   ```bash
+   cp .env.example .env
+   # Edit .env and set OPENAI_API_KEY
+   ```
+
+## Running the Application
+
+You can serve the application locally using the Agenta CLI:
+```bash
+agenta serve app.py
+```
+
+Or you can run it directly with Python:
+```bash
+python app.py
+```
+
+The application will be available at `http://localhost:8000` and can be interacted with via the Agenta platform or API.

--- a/examples/python/custom_workflows/instruction_executor/app.py
+++ b/examples/python/custom_workflows/instruction_executor/app.py
@@ -1,0 +1,72 @@
+from pydantic import BaseModel, Field
+import agenta as ag
+from agenta.sdk.types import MCField
+from agenta.sdk.assets import supported_llm_models
+from openai import OpenAI
+from opentelemetry.instrumentation.openai import OpenAIInstrumentor
+
+# Initialize Agenta
+ag.init()
+
+# Instrument OpenAI for tracing
+OpenAIInstrumentor().instrument()
+
+# Initialize OpenAI client
+client = OpenAI()
+
+# Define the default system prompt
+default_system_prompt = """
+You are an expert instruction-following AI assistant.
+You will be provided with some text and a set of instructions.
+Your task is to carefully execute the instructions on the provided text.
+Return only the final result.
+"""
+
+
+class Config(BaseModel):
+    system_prompt: str = Field(default=default_system_prompt)
+    model: str = MCField(default="gpt-3.5-turbo", choices=supported_llm_models)
+    temperature: float = Field(default=0.7, ge=0.0, le=2.0)
+    max_tokens: int = Field(default=1024, ge=1, le=4096)
+
+
+@ag.route("/", config_schema=Config)
+@ag.instrument()
+def execute_instruction(text: str, instructions: str):
+    """
+    Executes a set of instructions on the provided text using an LLM.
+
+    Args:
+        text (str): The input text to be processed.
+        instructions (str): The instructions to execute on the text.
+
+    Returns:
+        str: The result of executing the instructions.
+    """
+    # Retrieve configuration
+    config = ag.ConfigManager.get_from_route(Config)
+
+    # Format the user prompt
+    user_prompt = f"Instructions:\n{instructions}\n\nText:\n{text}"
+
+    # Call the LLM
+    completion = client.chat.completions.create(
+        model=config.model,
+        messages=[
+            {"role": "system", "content": config.system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=config.temperature,
+        max_tokens=config.max_tokens,
+    )
+
+    # Return the response content
+    return completion.choices[0].message.content
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        "agenta.sdk.decorators.routing:app", host="0.0.0.0", port=8000, reload=True
+    )

--- a/examples/python/custom_workflows/instruction_executor/requirements.txt
+++ b/examples/python/custom_workflows/instruction_executor/requirements.txt
@@ -1,0 +1,5 @@
+agenta
+openai
+pydantic
+opentelemetry-instrumentation-openai
+uvicorn


### PR DESCRIPTION
Added a new custom workflow example `instruction_executor` under `examples/python/custom_workflows/`.

This example demonstrates how to create a custom workflow in Agenta that takes an input `text` and a set of `instructions`, executing the instructions on the text using OpenAI. It leverages `@ag.route` and instrumented tracing using `opentelemetry-instrumentation-openai`.

Files included:
- `app.py`: Main workflow file with the Agenta route and logic.
- `requirements.txt`: Dependencies to run the workflow.
- `README.md`: Setup and execution instructions.
- `.env.example`: Template for environment variables.

---
*PR created automatically by Jules for task [14940211976481183175](https://jules.google.com/task/14940211976481183175) started by @eyeszik*